### PR TITLE
Typos  s/arb/acb in  `<acb_hypergeom_bessel_*>`  and `*.Rout.save` update

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flint
 Version: 0.1.5
 VersionNote: sync configure.ac, inst/NEWS.Rd
-Date: 2025-12-30
+Date: 2026-01-23
 Title: Fast Library for Number Theory
 Description:
 	An R interface to 'FLINT' <https://flintlib.org/>, a C library for

--- a/R/acb_special.R
+++ b/R/acb_special.R
@@ -28,29 +28,29 @@ function (z = 1, s, a = 1, prec = flintPrec()) {
 
 acb_hypgeom_bessel_j <-
 function (nu, z, prec = flintPrec()) {
-    res <- flintNew("arb")
-    .Call(R_flint_acb_hypgeom_bessel_j, res, as(nu, "arb"), as(z, "arb"), as(prec, "slong"))
+    res <- flintNew("acb")
+    .Call(R_flint_acb_hypgeom_bessel_j, res, as(nu, "acb"), as(z, "acb"), as(prec, "slong"))
     res
 }
 
 acb_hypgeom_bessel_y <-
 function (nu, z, prec = flintPrec()) {
-    res <- flintNew("arb")
-    .Call(R_flint_acb_hypgeom_bessel_y, res, as(nu, "arb"), as(z, "arb"), as(prec, "slong"))
+    res <- flintNew("acb")
+    .Call(R_flint_acb_hypgeom_bessel_y, res, as(nu, "acb"), as(z, "acb"), as(prec, "slong"))
     res
 }
 
 acb_hypgeom_bessel_i <-
 function (nu, z, prec = flintPrec()) {
-    res <- flintNew("arb")
-    .Call(R_flint_acb_hypgeom_bessel_i, res, as(nu, "arb"), as(z, "arb"), as(prec, "slong"))
+    res <- flintNew("acb")
+    .Call(R_flint_acb_hypgeom_bessel_i, res, as(nu, "acb"), as(z, "acb"), as(prec, "slong"))
     res
 }
 
 acb_hypgeom_bessel_k <-
 function (nu, z, prec = flintPrec()) {
-    res <- flintNew("arb")
-    .Call(R_flint_acb_hypgeom_bessel_k, res, as(nu, "arb"), as(z, "arb"), as(prec, "slong"))
+    res <- flintNew("acb")
+    .Call(R_flint_acb_hypgeom_bessel_k, res, as(nu, "acb"), as(z, "acb"), as(prec, "slong"))
     res
 }
 

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -1,7 +1,7 @@
 \name{NEWS}
 \title{News for \R{} Package \pkg{flint}}
 \newcommand{\GH}{\href{https://github.com/jaganmn/flint/issues/#1}{GH##1}}
-\section{Changes in version 0.1.5 (2025-12-30)}{
+\section{Changes in version 0.1.5 (2025-01-23)}{
   \subsection{Description}{
     \itemize{
       \item .
@@ -54,7 +54,8 @@
   }
   \subsection{Bug Fixes}{
     \itemize{
-      \item .
+      \item The four \code{acb_hypgeom_bessel_[jyik]()} functions now use
+      \code{as(*, "acb")} as they should.
     }
   }
   \subsection{Internals}{

--- a/tests/print.Rout.save
+++ b/tests/print.Rout.save
@@ -1,7 +1,7 @@
 
-R Under development (unstable) (2025-11-16 r89026) -- "Unsuffered Consequences"
-Copyright (C) 2025 The R Foundation for Statistical Computing
-Platform: aarch64-apple-darwin23.6.0
+R version 4.5.2 Patched (2026-01-19 r89323) -- "[Not] Part in a Rumble"
+Copyright (C) 2026 The R Foundation for Statistical Computing
+Platform: x86_64-pc-linux-gnu
 
 R is free software and comes with ABSOLUTELY NO WARRANTY.
 You are welcome to redistribute it under certain conditions.
@@ -261,10 +261,10 @@ class "arb", length 16, address <pointer: 0x102874ce0>
 > 
 > ## Row and column labels were not printed for arrays of length zero
 > ulong.array(0L, c(0L, 2L))
-class "ulong", dim (0,2), address <pointer: 0x0>
+class "ulong", dim (0,2), address <pointer: (nil)>
      [,1] [,2]
 > ulong.array(0L, c(2L, 0L))
-class "ulong", dim (2,0), address <pointer: 0x0>
+class "ulong", dim (2,0), address <pointer: (nil)>
     
 [1,]
 [2,]


### PR DESCRIPTION
"Obvious" very small things; found these when experimenting with the arb_*() ones..